### PR TITLE
Signed URLs are getting corrupted

### DIFF
--- a/resources/views/mails/test.blade.php
+++ b/resources/views/mails/test.blade.php
@@ -3,8 +3,8 @@
 
 Your order has been shipped!
 
-@component('mail::button', ['url' => 'https://spatie.be?hey=yo&option=value'])
-    View Order
+@component('mail::button', ['url' => \Illuminate\Support\Facades\URL::signedRoute('test')])
+    Show me the secrets!
 @endcomponent
 
 Thanks,<br>

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,6 +2,17 @@
 
 use Illuminate\Support\Facades\Route;
 
-Route::get('/', function () {
-    return view('welcome');
+use Illuminate\Http\Request;
+use Illuminate\Routing\Exceptions\InvalidSignatureException;
+
+Route::get("/", function () {
+    return view("welcome");
 });
+
+Route::get("/test", function (Request $request) {
+    if (!$request->hasValidSignature()) {
+        throw new InvalidSignatureException();
+    }
+
+    return response("Everything is fine, nothing to see here!");
+})->name("test");


### PR DESCRIPTION
As I described in https://github.com/spatie/laravel-ray/issues/343, the signed urls are getting corrupted. I assumed, that the problem is with `=` sign in general, but your example works of course. It must be somehow specific to signed urls only.

I'd like to take this opportunity to say a big thanks to you and the entire Spatie team for all your hard work. My card from Bydgoszcz in Poland has been with you guys for a while now. Thank you once again!